### PR TITLE
feat: Add TikTok to kktiktok domain conversion support

### DIFF
--- a/app/src/main/java/com/fixupxer/MainActivity.kt
+++ b/app/src/main/java/com/fixupxer/MainActivity.kt
@@ -386,7 +386,7 @@ class MainActivity : BaseActivity() {
                     }
                     binding.switchInstagram.isChecked = state.isInstagramConversionEnabled
                     
-                    binding.twitterToggleContainer.isVisible = state.isTwitterUrl
+                    binding.twitterToggleContainer.isVisible = state.isTwitterUrl || state.isTikTokUrl
                     binding.switchTwitter.isChecked = state.isTwitterConversionEnabled
                     
                     binding.progressIndicator.isVisible = state.isLoading

--- a/app/src/main/java/com/fixupxer/UrlProcessor.kt
+++ b/app/src/main/java/com/fixupxer/UrlProcessor.kt
@@ -145,6 +145,7 @@ class UrlProcessor @Inject constructor(
         val isInstagramProxy = Constants.INSTAGRAM_ALL_KNOWN_PROXIES.any {
             url.contains(it, ignoreCase = true)
         }
+        val isTikTok = isTikTokUrl(url)
 
         return when {
             // Instagram conversions — covers instagram.com + any of the 3 proxies
@@ -168,6 +169,11 @@ class UrlProcessor @Inject constructor(
             isFacebookUrl(url) && convertToAlternative -> convertToFacebookez(url)
             url.contains(Constants.FACEBOOKEZ_DOMAIN, ignoreCase = true) && !convertToAlternative ->
                 convertFromFacebookez(url)
+            
+            // TikTok conversions
+            isTikTok && convertToAlternative -> convertToKkTiktok(url)
+            url.contains(Constants.KKTIKTOK_DOMAIN, ignoreCase = true) && !convertToAlternative ->
+                convertFromKkTiktok(url)
             
             else -> url
         }
@@ -344,6 +350,56 @@ class UrlProcessor @Inject constructor(
         val lowerUrl = url.lowercase()
         return lowerUrl.contains(Constants.FACEBOOK_DOMAIN) || 
                lowerUrl.contains(Constants.FACEBOOKEZ_DOMAIN)
+    }
+    
+    /**
+     * Check if a URL is a TikTok URL
+     */
+    fun isTikTokUrl(url: String): Boolean {
+        val lowerUrl = url.lowercase()
+        return lowerUrl.contains(Constants.TIKTOK_DOMAIN) ||
+               lowerUrl.contains(Constants.KKTIKTOK_DOMAIN) ||
+               lowerUrl.contains("tiktokcdn.com") ||
+               lowerUrl.contains("tiktokv.com")
+    }
+
+    /**
+     * Convert TikTok URLs to kktiktok.com
+     */
+    private fun convertToKkTiktok(url: String): String {
+        if (url.contains(Constants.KKTIKTOK_DOMAIN, ignoreCase = true)) return url
+        
+        // Match tiktok.com or tiktokv.com and replace with kktiktok.com, preserving subdomains
+        val regex = Regex("(?<=https?://)(?:[a-zA-Z0-9-]+\\.)?(?:tiktok\\.com|tiktokv\\.com)", RegexOption.IGNORE_CASE)
+        val match = regex.find(url)
+        return if (match != null) {
+            val matchedHost = match.value
+            val targetHost = matchedHost
+                .replace("tiktok.com", "kktiktok.com", ignoreCase = true)
+                .replace("tiktokv.com", "kktiktok.com", ignoreCase = true)
+            url.replaceFirst(matchedHost, targetHost)
+        } else {
+            url.replace("tiktok.com", "kktiktok.com", ignoreCase = true)
+               .replace("tiktokv.com", "kktiktok.com", ignoreCase = true)
+        }
+    }
+
+    /**
+     * Convert kktiktok.com back to tiktok.com
+     */
+    private fun convertFromKkTiktok(url: String): String {
+        if (!url.contains(Constants.KKTIKTOK_DOMAIN, ignoreCase = true)) return url
+        
+        // Match kktiktok.com and replace with tiktok.com, preserving subdomains
+        val regex = Regex("(?<=https?://)(?:[a-zA-Z0-9-]+\\.)?kktiktok\\.com", RegexOption.IGNORE_CASE)
+        val match = regex.find(url)
+        return if (match != null) {
+            val matchedHost = match.value
+            val targetHost = matchedHost.replace("kktiktok.com", "tiktok.com", ignoreCase = true)
+            url.replaceFirst(matchedHost, targetHost)
+        } else {
+            url.replace("kktiktok.com", "tiktok.com", ignoreCase = true)
+        }
     }
     
     /**

--- a/app/src/main/java/com/fixupxer/data/repository/UrlRepositoryImpl.kt
+++ b/app/src/main/java/com/fixupxer/data/repository/UrlRepositoryImpl.kt
@@ -54,11 +54,13 @@ class UrlRepositoryImpl @Inject constructor(
         val isInstagram = urlProcessor.isInstagramUrl(url)
         val isTwitter = urlProcessor.isTwitterUrl(url)
         val isFacebook = urlProcessor.isFacebookUrl(url)
+        val isTikTok = urlProcessor.isTikTokUrl(url)
         
         val platform = when {
             isInstagram -> "Instagram"
             isTwitter -> "Twitter/X"
             isFacebook -> "Facebook"
+            isTikTok -> "TikTok"
             else -> "Other"
         }
         
@@ -78,6 +80,14 @@ class UrlRepositoryImpl @Inject constructor(
                 url,
                 cleanTracking = forceCleanTracking || preferencesManager.isCleanTrackingEnabled(),
                 convertTwitter = preferencesManager.isConvertInstagramEnabled(),
+                instagramProxy = instagramProxy
+            )
+        } else if (isTikTok) {
+            // For TikTok URLs, use the Twitter conversion preference (same toggle)
+            urlProcessor.processUrl(
+                url,
+                cleanTracking = forceCleanTracking || preferencesManager.isCleanTrackingEnabled(),
+                convertTwitter = preferencesManager.isConvertTwitterEnabled(),
                 instagramProxy = instagramProxy
             )
         } else {
@@ -123,6 +133,8 @@ class UrlRepositoryImpl @Inject constructor(
                 url.contains("fixupx.com") && processedUrl.contains("twitter.com") -> "Domain converted"
                 url.contains("fxtwitter.com") && processedUrl.contains("fixupx.com") -> "Domain converted"
                 url.contains("fxtwitter.com") && processedUrl.contains("x.com") -> "Domain converted"
+                url.contains("tiktok.com") && processedUrl.contains("kktiktok.com") -> "Domain converted"
+                url.contains("kktiktok.com") && processedUrl.contains("tiktok.com") -> "Domain converted"
                 trackingRemoved -> "Tracking removed"
                 else -> "URL cleaned"
             }
@@ -197,6 +209,8 @@ class UrlRepositoryImpl @Inject constructor(
     
     override fun isTwitterUrl(url: String): Boolean = urlProcessor.isTwitterUrl(url)
     
+    override fun isTikTokUrl(url: String): Boolean = urlProcessor.isTikTokUrl(url)
+    
     override fun hasTrackingParameters(url: String): Boolean = urlProcessor.hasTrackingParameters(url)
     
     override fun isInstagramConversionEnabled(): Flow<Boolean> = flowOf(preferencesManager.isConvertInstagramEnabled())
@@ -229,11 +243,13 @@ class UrlRepositoryImpl @Inject constructor(
         val isInstagram = urlProcessor.isInstagramUrl(url)
         val isTwitter = urlProcessor.isTwitterUrl(url)
         val isFacebook = urlProcessor.isFacebookUrl(url)
+        val isTikTok = urlProcessor.isTikTokUrl(url)
         
         val platform = when {
             isInstagram -> "Instagram"
             isTwitter -> "Twitter/X"
             isFacebook -> "Facebook"
+            isTikTok -> "TikTok"
             else -> "Other"
         }
         
@@ -257,6 +273,14 @@ class UrlRepositoryImpl @Inject constructor(
                 )
             }
             isTwitter -> {
+                urlProcessor.processUrl(
+                    url,
+                    cleanTracking = preferencesManager.isCleanTrackingEnabled(),
+                    convertTwitter = preferencesManager.isBrowserConvertTwitterEnabled(),
+                    instagramProxy = instagramProxy
+                )
+            }
+            isTikTok -> {
                 urlProcessor.processUrl(
                     url,
                     cleanTracking = preferencesManager.isCleanTrackingEnabled(),

--- a/app/src/main/java/com/fixupxer/domain/repository/UrlRepository.kt
+++ b/app/src/main/java/com/fixupxer/domain/repository/UrlRepository.kt
@@ -73,6 +73,13 @@ interface UrlRepository {
     fun isTwitterUrl(url: String): Boolean
     
     /**
+     * Check if a URL is a TikTok URL
+     * @param url The URL to check
+     * @return True if it's a TikTok URL
+     */
+    fun isTikTokUrl(url: String): Boolean
+    
+    /**
      * Check if a URL contains tracking parameters
      */
     fun hasTrackingParameters(url: String): Boolean

--- a/app/src/main/java/com/fixupxer/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/fixupxer/presentation/main/MainViewModel.kt
@@ -92,6 +92,12 @@ class MainViewModel @Inject constructor(
         } else {
             false
         }
+
+        val isTikTok = if (url.isNotEmpty()) {
+            urlRepository.isTikTokUrl(url)
+        } else {
+            false
+        }
         
         _uiState.update { 
             it.copy(
@@ -99,6 +105,7 @@ class MainViewModel @Inject constructor(
                 isInstagramUrl = isInstagram,
                 isFacebookUrl = isFacebook,
                 isTwitterUrl = showTwitterToggle,
+                isTikTokUrl = isTikTok,
                 error = null,
                 showErrorToast = false
             )
@@ -219,6 +226,7 @@ class MainViewModel @Inject constructor(
                 processedUrl = "",
                 isInstagramUrl = false,
                 isFacebookUrl = false,
+                isTikTokUrl = false,
                 error = null,
                 showErrorToast = false
             )
@@ -232,6 +240,7 @@ class MainViewModel @Inject constructor(
                 processedUrl = "",
                 isInstagramUrl = false,
                 isFacebookUrl = false,
+                isTikTokUrl = false,
                 error = getApplication<Application>().getString(R.string.error_multiple_urls),
                 showErrorToast = false
             )
@@ -251,6 +260,7 @@ data class MainUiState(
     val isInstagramConversionEnabled: Boolean = true,
     val isTwitterUrl: Boolean = false,
     val isTwitterConversionEnabled: Boolean = true,
+    val isTikTokUrl: Boolean = false,
     val error: String? = null,
     val showErrorToast: Boolean = false
 ) 

--- a/app/src/main/java/com/fixupxer/presentation/share/ShareViewModel.kt
+++ b/app/src/main/java/com/fixupxer/presentation/share/ShareViewModel.kt
@@ -120,11 +120,14 @@ class ShareViewModel @Inject constructor(
                     val isFacebook = url.contains("facebook.com", ignoreCase = true) ||
                                      url.contains("facebookez.com", ignoreCase = true)
                     
+                    val isTikTok = urlRepository.isTikTokUrl(url)
+                    
                     _uiState.update { 
                         it.copy(
                             isInstagramUrl = isInstagram,
                             isFacebookUrl = isFacebook,
-                            isTwitterUrl = isTwitter
+                            isTwitterUrl = isTwitter,
+                            isTikTokUrl = isTikTok
                         ) 
                     }
                     
@@ -264,6 +267,7 @@ class ShareViewModel @Inject constructor(
                 processedUrl = "",
                 isInstagramUrl = false,
                 isFacebookUrl = false,
+                isTikTokUrl = false,
                 error = null
             )
         }
@@ -282,5 +286,6 @@ data class ShareUiState(
     val isInstagramConversionEnabled: Boolean = true,
     val isTwitterUrl: Boolean = false,
     val isTwitterConversionEnabled: Boolean = true,
+    val isTikTokUrl: Boolean = false,
     val error: String? = null
 ) 

--- a/app/src/main/java/com/fixupxer/ui/ShareActivity.kt
+++ b/app/src/main/java/com/fixupxer/ui/ShareActivity.kt
@@ -293,7 +293,7 @@ class ShareActivity : BaseActivity() {
                         viewModel.onInstagramConversionToggled(isChecked)
                     }
                     
-                    binding.twitterToggleContainer.isVisible = state.isTwitterUrl
+                    binding.twitterToggleContainer.isVisible = state.isTwitterUrl || state.isTikTokUrl
                     
                     // Temporarily remove listener to avoid triggering when setting programmatically
                     binding.switchTwitter.setOnCheckedChangeListener(null)

--- a/app/src/main/java/com/fixupxer/utils/Constants.kt
+++ b/app/src/main/java/com/fixupxer/utils/Constants.kt
@@ -56,6 +56,8 @@ object Constants {
     const val VXTWITTER_DOMAIN = "vxtwitter.com"
     const val FACEBOOK_DOMAIN = "facebook.com"
     const val FACEBOOKEZ_DOMAIN = "facebookez.com"
+    const val TIKTOK_DOMAIN = "tiktok.com"
+    const val KKTIKTOK_DOMAIN = "kktiktok.com"
     
     // URL path identifiers
     const val TWITTER_STATUS_PATH = "/status/"

--- a/app/src/test/java/com/fixupxer/UrlProcessorMatrixTest.kt
+++ b/app/src/test/java/com/fixupxer/UrlProcessorMatrixTest.kt
@@ -144,7 +144,9 @@ class UrlProcessorMatrixTest {
             Case("tiktok clean, toggle ON", "https://www.tiktok.com/t/1", true, true, "https://www.kktiktok.com/t/1", false, false),
             Case("vm tiktok clean, toggle ON", "https://vm.tiktok.com/t/1", true, true, "https://vm.kktiktok.com/t/1", false, false),
             Case("kktiktok clean, toggle OFF", "https://www.kktiktok.com/t/1", true, false, "https://www.tiktok.com/t/1", false, false),
-            Case("kktiktok clean, toggle ON", "https://www.kktiktok.com/t/1", true, true, "https://www.kktiktok.com/t/1", true, true)
+            Case("kktiktok clean, toggle ON", "https://www.kktiktok.com/t/1", true, true, "https://www.kktiktok.com/t/1", true, true),
+            Case("tiktok dirty, toggle ON", "https://www.tiktok.com/@user/video/1?_r=1&_t=abc&lang=en", true, true, "https://www.kktiktok.com/@user/video/1?lang=en", false, false),
+            Case("tiktok dirty, toggle OFF", "https://www.tiktok.com/@user/video/1?_r=1&_t=abc&lang=en", true, false, "https://www.tiktok.com/@user/video/1?lang=en", false, false)
         )
 
         cases.forEach { c ->

--- a/app/src/test/java/com/fixupxer/UrlProcessorMatrixTest.kt
+++ b/app/src/test/java/com/fixupxer/UrlProcessorMatrixTest.kt
@@ -142,6 +142,7 @@ class UrlProcessorMatrixTest {
             // === TikTok ===
             Case("tiktok clean, toggle OFF", "https://www.tiktok.com/t/1", true, false, "https://www.tiktok.com/t/1", true, true),
             Case("tiktok clean, toggle ON", "https://www.tiktok.com/t/1", true, true, "https://www.kktiktok.com/t/1", false, false),
+            Case("tiktok clean without www, toggle ON", "https://tiktok.com/t/1", true, true, "https://kktiktok.com/t/1", false, false),
             Case("vm tiktok clean, toggle ON", "https://vm.tiktok.com/t/1", true, true, "https://vm.kktiktok.com/t/1", false, false),
             Case("kktiktok clean, toggle OFF", "https://www.kktiktok.com/t/1", true, false, "https://www.tiktok.com/t/1", false, false),
             Case("kktiktok clean, toggle ON", "https://www.kktiktok.com/t/1", true, true, "https://www.kktiktok.com/t/1", true, true),

--- a/app/src/test/java/com/fixupxer/UrlProcessorMatrixTest.kt
+++ b/app/src/test/java/com/fixupxer/UrlProcessorMatrixTest.kt
@@ -137,7 +137,14 @@ class UrlProcessorMatrixTest {
             Case("fxtwitter.com clean, toggle ON", "https://fxtwitter.com/user/status/1", true, true, "https://fixupx.com/user/status/1", false, false),
             // Dirty fxtwitter.com
             Case("fxtwitter.com dirty, toggle OFF", "https://fxtwitter.com/user/status/1?utm_source=abc", true, false, "https://x.com/user/status/1", false, false),
-            Case("fxtwitter.com dirty, toggle ON", "https://fxtwitter.com/user/status/1?utm_source=abc", true, true, "https://fixupx.com/user/status/1", false, false)
+            Case("fxtwitter.com dirty, toggle ON", "https://fxtwitter.com/user/status/1?utm_source=abc", true, true, "https://fixupx.com/user/status/1", false, false),
+
+            // === TikTok ===
+            Case("tiktok clean, toggle OFF", "https://www.tiktok.com/t/1", true, false, "https://www.tiktok.com/t/1", true, true),
+            Case("tiktok clean, toggle ON", "https://www.tiktok.com/t/1", true, true, "https://www.kktiktok.com/t/1", false, false),
+            Case("vm tiktok clean, toggle ON", "https://vm.tiktok.com/t/1", true, true, "https://vm.kktiktok.com/t/1", false, false),
+            Case("kktiktok clean, toggle OFF", "https://www.kktiktok.com/t/1", true, false, "https://www.tiktok.com/t/1", false, false),
+            Case("kktiktok clean, toggle ON", "https://www.kktiktok.com/t/1", true, true, "https://www.kktiktok.com/t/1", true, true)
         )
 
         cases.forEach { c ->

--- a/app/src/test/java/com/fixupxer/UrlProcessorTest.kt
+++ b/app/src/test/java/com/fixupxer/UrlProcessorTest.kt
@@ -104,6 +104,33 @@ class UrlProcessorTest {
     }
     
     @Test
+    fun `test convert TikTok URL to kktiktok`() {
+        val tiktokUrl = "https://www.tiktok.com/t/ZTB4YXjhF/"
+        val resultPair = urlProcessor.processUrl(tiktokUrl, cleanTracking = false, convertTwitter = true)
+        println("Converted TikTok result: ${resultPair.first}")
+        val expected = "https://www.kktiktok.com/t/ZTB4YXjhF/"
+        assertEquals(expected, resultPair.first)
+    }
+    
+    @Test
+    fun `test convert vm TikTok URL to kktiktok`() {
+        val tiktokUrl = "https://vm.tiktok.com/ZTB4YXjhF/"
+        val resultPair = urlProcessor.processUrl(tiktokUrl, cleanTracking = false, convertTwitter = true)
+        println("Converted TikTok result: ${resultPair.first}")
+        val expected = "https://vm.kktiktok.com/ZTB4YXjhF/"
+        assertEquals(expected, resultPair.first)
+    }
+
+    @Test
+    fun `test convert kktiktok URL back to tiktok`() {
+        val proxyUrl = "https://www.kktiktok.com/t/ZTB4YXjhF/"
+        val resultPair = urlProcessor.processUrl(proxyUrl, cleanTracking = false, convertTwitter = false)
+        println("Reverted TikTok result: ${resultPair.first}")
+        val expected = "https://www.tiktok.com/t/ZTB4YXjhF/"
+        assertEquals(expected, resultPair.first)
+    }
+    
+    @Test
     fun `test convert X com URL to FixupX`() {
         val xUrl = "https://x.com/user/status/1234567890"
         val resultPair = urlProcessor.processUrl(xUrl, cleanTracking = false, convertTwitter = true)

--- a/app/src/test/java/com/fixupxer/UrlProcessorTest.kt
+++ b/app/src/test/java/com/fixupxer/UrlProcessorTest.kt
@@ -131,6 +131,26 @@ class UrlProcessorTest {
     }
     
     @Test
+    fun `test clean TikTok URL with tracking parameters and embed ON`() {
+        val tiktokUrl = "https://www.tiktok.com/@user/video/1234567890?_r=1&_t=abc&lang=en"
+        val resultPair = urlProcessor.processUrl(tiktokUrl, cleanTracking = true, convertTwitter = true)
+        println("TikTok result: ${resultPair.first}")
+        val expected = "https://www.kktiktok.com/@user/video/1234567890?lang=en"
+        assertEquals(expected, resultPair.first)
+        assertFalse(resultPair.second)
+    }
+
+    @Test
+    fun `test clean TikTok URL with tracking parameters and embed OFF`() {
+        val tiktokUrl = "https://www.tiktok.com/@user/video/1234567890?_r=1&_t=abc&lang=en"
+        val resultPair = urlProcessor.processUrl(tiktokUrl, cleanTracking = true, convertTwitter = false)
+        println("TikTok result: ${resultPair.first}")
+        val expected = "https://www.tiktok.com/@user/video/1234567890?lang=en"
+        assertEquals(expected, resultPair.first)
+        assertFalse(resultPair.second)
+    }
+    
+    @Test
     fun `test convert X com URL to FixupX`() {
         val xUrl = "https://x.com/user/status/1234567890"
         val resultPair = urlProcessor.processUrl(xUrl, cleanTracking = false, convertTwitter = true)

--- a/app/src/test/java/com/fixupxer/UrlProcessorTest.kt
+++ b/app/src/test/java/com/fixupxer/UrlProcessorTest.kt
@@ -113,6 +113,15 @@ class UrlProcessorTest {
     }
     
     @Test
+    fun `test convert TikTok URL without www to kktiktok`() {
+        val tiktokUrl = "https://tiktok.com/t/ZTB4YXjhF/"
+        val resultPair = urlProcessor.processUrl(tiktokUrl, cleanTracking = false, convertTwitter = true)
+        println("Converted TikTok result: ${resultPair.first}")
+        val expected = "https://kktiktok.com/t/ZTB4YXjhF/"
+        assertEquals(expected, resultPair.first)
+    }
+    
+    @Test
     fun `test convert vm TikTok URL to kktiktok`() {
         val tiktokUrl = "https://vm.tiktok.com/ZTB4YXjhF/"
         val resultPair = urlProcessor.processUrl(tiktokUrl, cleanTracking = false, convertTwitter = true)


### PR DESCRIPTION
## Description
This PR implements domain conversion support for TikTok links to the `kktiktok.com` embed proxy when the "Embed?" toggle is enabled, and reverts it back to `tiktok.com` when the toggle is off.

Since the application operates 100% locally and offline without the `INTERNET` permission, it is unable to follow redirects or resolve shortened paths like `tiktok.com/t/` directly. Rewriting these links to `kktiktok.com` delegates resolution to the proxy client-side, making them instantly embeddable when shared.

## Key Changes
- Added `TIKTOK_DOMAIN` and `KKTIKTOK_DOMAIN` to `Constants.kt`.
- Implemented `isTikTokUrl`, `convertToKkTiktok`, and `convertFromKkTiktok` in `UrlProcessor.kt`, preserving subdomains (such as `vm.tiktok.com` -> `vm.kktiktok.com`).
- Integrated TikTok domain conversion logic into `UrlRepositoryImpl.kt` for both normal and browser mode URL processing.
- Updated `MainViewModel.kt` and `ShareViewModel.kt` to track TikTok link visibility.
- Enabled the toggle container to display dynamically for TikTok URLs in `MainActivity.kt` and `ShareActivity.kt`.
- Added unit tests in `UrlProcessorTest.kt` and `UrlProcessorMatrixTest.kt` covering parameter cleaning and domain conversion/reversion states, including links without the `www` subdomain prefix.

## Testing
- Verified that TikTok links without `www` (e.g. `https://tiktok.com/t/1`) convert to `https://kktiktok.com/t/1` with the toggle ON.
- Verified that dirty TikTok links have tracking parameters removed while preserving functional query parameters (e.g. `lang`).
